### PR TITLE
feat: Add watchOS companion app

### DIFF
--- a/WatchApp/ClickerWatchApp.swift
+++ b/WatchApp/ClickerWatchApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct ClickerWatchApp: App {
+    @StateObject private var connectionManager = WatchConnectionManager()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(connectionManager)
+        }
+    }
+}

--- a/WatchApp/ContentView.swift
+++ b/WatchApp/ContentView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import WatchKit
+
+struct ContentView: View {
+    @EnvironmentObject var connectionManager: WatchConnectionManager
+    @State private var elapsedSeconds: Int = 0
+    @State private var timerRunning = false
+    @State private var timer: Timer?
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 8) {
+                // Previous slide button (top)
+                Button(action: {
+                    WKInterfaceDevice.current().play(.click)
+                    connectionManager.previousSlide()
+                }) {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 32, weight: .bold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: geometry.size.height * 0.35)
+                        .background(Color.blue.opacity(0.3))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+
+                // Timer display (middle)
+                Button(action: {
+                    toggleTimer()
+                }) {
+                    VStack(spacing: 2) {
+                        Text(formattedTime)
+                            .font(.system(size: 24, weight: .medium, design: .monospaced))
+                            .foregroundColor(timerRunning ? .green : .white)
+
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(connectionManager.isConnectedToMac ? Color.green : Color.red)
+                                .frame(width: 6, height: 6)
+                            Text(connectionManager.isConnectedToMac ? "Connected" : "Disconnected")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+
+                // Next slide button (bottom)
+                Button(action: {
+                    WKInterfaceDevice.current().play(.click)
+                    connectionManager.nextSlide()
+                }) {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 32, weight: .bold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: geometry.size.height * 0.35)
+                        .background(Color.blue.opacity(0.3))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Timer
+    private var formattedTime: String {
+        let minutes = elapsedSeconds / 60
+        let seconds = elapsedSeconds % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    private func toggleTimer() {
+        if timerRunning {
+            // Stop timer
+            timer?.invalidate()
+            timer = nil
+            timerRunning = false
+        } else {
+            // Start timer
+            timerRunning = true
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+                elapsedSeconds += 1
+            }
+        }
+        WKInterfaceDevice.current().play(.click)
+    }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(WatchConnectionManager())
+}

--- a/WatchApp/Info.plist
+++ b/WatchApp/Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/WatchApp/WatchConnectionManager.swift
+++ b/WatchApp/WatchConnectionManager.swift
@@ -1,0 +1,157 @@
+import Foundation
+import WatchConnectivity
+import Combine
+
+class WatchConnectionManager: NSObject, ObservableObject {
+
+    // MARK: - Published Properties
+    @Published var isReachable = false
+    @Published var isConnectedToMac = false
+
+    // MARK: - Private Properties
+    private var session: WCSession?
+    private var pendingCommand: String?
+    private var retryTimer: Timer?
+    private let maxRetries = 3
+    private var retryCount = 0
+
+    // MARK: - Initialization
+    override init() {
+        super.init()
+
+        if WCSession.isSupported() {
+            session = WCSession.default
+            session?.delegate = self
+            session?.activate()
+        }
+    }
+
+    // MARK: - Send Commands
+    func sendCommand(_ command: String) {
+        guard let session = session, session.activationState == .activated else {
+            print("⌚ WCSession not activated")
+            return
+        }
+
+        let message = ["command": command]
+
+        if session.isReachable {
+            // iPhone is reachable - send immediately
+            session.sendMessage(message, replyHandler: { reply in
+                DispatchQueue.main.async {
+                    if let connected = reply["connectedToMac"] as? Bool {
+                        self.isConnectedToMac = connected
+                    }
+                    print("⌚ Command sent successfully: \(command)")
+                }
+                self.clearPendingCommand()
+            }, errorHandler: { error in
+                print("⌚ sendMessage failed: \(error.localizedDescription)")
+                self.queueRetry(command: command)
+            })
+        } else {
+            // iPhone not reachable - queue for retry
+            print("⌚ iPhone not reachable, queuing command")
+            queueRetry(command: command)
+        }
+    }
+
+    // MARK: - Retry Logic
+    private func queueRetry(command: String) {
+        pendingCommand = command
+        retryCount = 0
+        scheduleRetry()
+    }
+
+    private func scheduleRetry() {
+        retryTimer?.invalidate()
+
+        guard retryCount < maxRetries else {
+            print("⌚ Max retries reached, giving up")
+            clearPendingCommand()
+            return
+        }
+
+        retryTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
+            self?.attemptRetry()
+        }
+    }
+
+    private func attemptRetry() {
+        guard let command = pendingCommand,
+              let session = session,
+              session.isReachable else {
+            retryCount += 1
+            scheduleRetry()
+            return
+        }
+
+        let message = ["command": command]
+        session.sendMessage(message, replyHandler: { reply in
+            DispatchQueue.main.async {
+                if let connected = reply["connectedToMac"] as? Bool {
+                    self.isConnectedToMac = connected
+                }
+            }
+            self.clearPendingCommand()
+            print("⌚ Retry successful: \(command)")
+        }, errorHandler: { [weak self] error in
+            print("⌚ Retry failed: \(error.localizedDescription)")
+            self?.retryCount += 1
+            self?.scheduleRetry()
+        })
+    }
+
+    private func clearPendingCommand() {
+        pendingCommand = nil
+        retryTimer?.invalidate()
+        retryTimer = nil
+        retryCount = 0
+    }
+
+    // MARK: - Convenience Methods
+    func nextSlide() {
+        sendCommand("next")
+    }
+
+    func previousSlide() {
+        sendCommand("previous")
+    }
+}
+
+// MARK: - WCSessionDelegate
+extension WatchConnectionManager: WCSessionDelegate {
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async {
+            self.isReachable = session.isReachable
+        }
+
+        if let error = error {
+            print("⌚ WCSession activation failed: \(error.localizedDescription)")
+        } else {
+            print("⌚ WCSession activated: \(activationState.rawValue)")
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async {
+            self.isReachable = session.isReachable
+            print("⌚ Reachability changed: \(session.isReachable)")
+        }
+
+        // Retry pending command if we just became reachable
+        if session.isReachable, pendingCommand != nil {
+            attemptRetry()
+        }
+    }
+
+    // Receive status updates from iPhone
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        DispatchQueue.main.async {
+            if let connected = applicationContext["connectedToMac"] as? Bool {
+                self.isConnectedToMac = connected
+            }
+        }
+    }
+}

--- a/iPhoneApp/iPhoneConnectionManager.swift
+++ b/iPhoneApp/iPhoneConnectionManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MultipeerConnectivity
+import WatchConnectivity
 import Combine
 
 // MARK: - iPhone Connection Manager
@@ -26,14 +27,41 @@ class iPhoneConnectionManager: NSObject, ObservableObject {
 
     // MARK: - Haptic Feedback
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-    
+
+    // MARK: - Watch Connectivity
+    private var watchSession: WCSession?
+
     // MARK: - Initialization
     override init() {
         self.myPeerID = MCPeerID(displayName: UIDevice.current.name)
         super.init()
         setupSession()
+        setupWatchConnectivity()
         feedbackGenerator.prepare()
         startBrowsing()
+    }
+
+    private func setupWatchConnectivity() {
+        if WCSession.isSupported() {
+            watchSession = WCSession.default
+            watchSession?.delegate = self
+            watchSession?.activate()
+            print("📱 WatchConnectivity activated")
+        }
+    }
+
+    private func updateWatchWithConnectionStatus() {
+        guard let watchSession = watchSession,
+              watchSession.activationState == .activated,
+              watchSession.isPaired,
+              watchSession.isWatchAppInstalled else { return }
+
+        do {
+            try watchSession.updateApplicationContext(["connectedToMac": isConnected])
+            print("📱 Sent connection status to watch: \(isConnected)")
+        } catch {
+            print("📱 Failed to update watch context: \(error.localizedDescription)")
+        }
     }
     
     private func setupSession() {
@@ -187,6 +215,7 @@ extension iPhoneConnectionManager: MCSessionDelegate {
                 self.reconnectTimer?.invalidate()
                 self.reconnectTimer = nil
                 self.startKeepalive()
+                self.updateWatchWithConnectionStatus()
                 // Keep browsing active for faster reconnection on hotspot
                 self.isSearching = false
 
@@ -200,6 +229,7 @@ extension iPhoneConnectionManager: MCSessionDelegate {
                     self.connectedMac = nil
                     self.isConnected = false
                     self.stopKeepalive()
+                    self.updateWatchWithConnectionStatus()
                     // Auto-reconnect if we had a previous connection
                     if self.lastConnectedMacName != nil {
                         self.statusMessage = "Connection lost, reconnecting..."
@@ -258,5 +288,49 @@ extension iPhoneConnectionManager: MCNearbyServiceBrowserDelegate {
             self.isSearching = false
             self.statusMessage = "Error: \(error.localizedDescription)"
         }
+    }
+}
+
+// MARK: - WCSessionDelegate (Watch Connectivity)
+extension iPhoneConnectionManager: WCSessionDelegate {
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("📱 WCSession activation failed: \(error.localizedDescription)")
+        } else {
+            print("📱 WCSession activated: \(activationState.rawValue)")
+            DispatchQueue.main.async {
+                self.updateWatchWithConnectionStatus()
+            }
+        }
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        print("📱 WCSession became inactive")
+    }
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        print("📱 WCSession deactivated, reactivating...")
+        session.activate()
+    }
+
+    // Handle messages from Apple Watch
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        guard let command = message["command"] as? String else {
+            replyHandler(["error": "Invalid command", "connectedToMac": isConnected])
+            return
+        }
+
+        print("📱 Received command from watch: \(command)")
+
+        // Relay command to Mac
+        if let remoteCommand = RemoteCommand(rawValue: command) {
+            DispatchQueue.main.async {
+                self.sendCommand(remoteCommand)
+            }
+        }
+
+        // Reply with current connection status
+        replyHandler(["success": true, "connectedToMac": isConnected])
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,7 @@ options:
   deploymentTarget:
     macOS: "14.0"
     iOS: "18.0"
+    watchOS: "10.0"
   xcodeVersion: "16.0"
   generateEmptyDirectories: true
 
@@ -93,6 +94,39 @@ targets:
         TARGETED_DEVICE_FAMILY: "1"  # iPhone only
         SUPPORTS_MAC_DESIGNED_FOR_IPHONE: false
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+    dependencies:
+      - target: ClickerWatch
+        embed: true
+
+  # ─────────────────────────────────────────────────────────────
+  # Apple Watch App
+  # ─────────────────────────────────────────────────────────────
+  ClickerWatch:
+    type: application
+    platform: watchOS
+    sources:
+      - path: WatchApp
+        excludes:
+          - "*.plist"
+      - path: Shared
+    info:
+      path: WatchApp/Info.plist
+      properties:
+        CFBundleName: ClickerWatch
+        WKApplication: true
+        WKCompanionAppBundleIdentifier: com.dou.clicker-ios
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.dou.clicker-ios.watchkitapp
+        PRODUCT_NAME: ClickerWatch
+        WATCHOS_DEPLOYMENT_TARGET: "10.0"
+        MARKETING_VERSION: "1.2"
+        CURRENT_PROJECT_VERSION: "1"
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: HD35YQ72U4
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        SDKROOT: watchos
+        TARGETED_DEVICE_FAMILY: "4"  # Watch only
 
 schemes:
   ClickerMac:
@@ -108,8 +142,18 @@ schemes:
     build:
       targets:
         ClickeriOS: all
+        ClickerWatch: all
     run:
       config: Debug
       storeKitConfiguration: iPhoneApp/Products.storekit
+    archive:
+      config: Release
+
+  ClickerWatch:
+    build:
+      targets:
+        ClickerWatch: all
+    run:
+      config: Debug
     archive:
       config: Release


### PR DESCRIPTION
## Summary
Adds a watchOS companion app for controlling presentations from your Apple Watch.

## Architecture
```
Watch → iPhone (WCSession) → Mac (MultipeerConnectivity)
```

## New Files
- `WatchApp/ClickerWatchApp.swift` - Main entry point
- `WatchApp/ContentView.swift` - Large chevron buttons + timer
- `WatchApp/WatchConnectionManager.swift` - WatchConnectivity with sendMessage + retry
- `WatchApp/Info.plist` - Base plist

## Modified Files
- `project.yml` - Added ClickerWatch target (watchOS 10.0+)
- `iPhoneConnectionManager.swift` - Added WCSessionDelegate relay

## Watch UI
- ⬆️ Previous slide (top button)
- ⏱️ Timer + connection status (middle, tappable)
- ⬇️ Next slide (bottom button)
- Haptic feedback on all buttons

## To Test
```bash
xcodegen generate
# Build ClickerWatch scheme in Xcode
```

---
*Implemented by Joan 🌀*